### PR TITLE
fix(dr): Meta trashcan PR from EO for testing

### DIFF
--- a/lib/dragonrealms/commons/common-items.rb
+++ b/lib/dragonrealms/commons/common-items.rb
@@ -423,17 +423,48 @@ module Lich
         return unless DRCI.get_item_if_not_held?(item)
 
         if worn_trashcan
-          case DRC.bput("put my #{item} in my #{worn_trashcan}", DROP_TRASH_RETRY_PATTERNS, DROP_TRASH_SUCCESS_PATTERNS, DROP_TRASH_FAILURE_PATTERNS, /^Perhaps you should be holding that first/)
-          when /^Perhaps you should be holding that first/
-            return (DRCI.get_item?(item) && DRCI.dispose_trash(item, worn_trashcan, worn_trashcan_verb))
-          when *DROP_TRASH_RETRY_PATTERNS
-            return DRCI.dispose_trash(item, worn_trashcan, worn_trashcan_verb)
+          case DRC.bput("put my #{item} in my #{worn_trashcan}", DROP_TRASH_SUCCESS_PATTERNS, DROP_TRASH_FAILURE_PATTERNS, DROP_TRASH_RETRY_PATTERNS, /^Perhaps you should be holding that first/)
           when *DROP_TRASH_SUCCESS_PATTERNS
             if worn_trashcan_verb
               DRC.bput("#{worn_trashcan_verb} my #{worn_trashcan}", *WORN_TRASHCAN_VERB_PATTERNS)
               DRC.bput("#{worn_trashcan_verb} my #{worn_trashcan}", *WORN_TRASHCAN_VERB_PATTERNS)
             end
             return true
+          when *DROP_TRASH_FAILURE_PATTERNS
+            # NOOP, try next trashcan option
+          when *DROP_TRASH_RETRY_PATTERNS
+            return DRCI.dispose_trash(item, worn_trashcan, worn_trashcan_verb)
+          when /^Perhaps you should be holding that first/
+            return (DRCI.get_item?(item) && DRCI.dispose_trash(item, worn_trashcan, worn_trashcan_verb))
+          end
+        end
+
+        # Check for meta:trashcan tag on the room to identify a specific trashcan to use.
+        if Room.current.tags.find { |t| t =~ /meta:trashcan:(.*)/ }
+          metatag_trashcan = Regexp.last_match(1)
+
+          # Gelapod needs special handling since you feed it, and it disappears in winter
+          metatag_trash_command = nil
+          if metatag_trashcan == 'gelapod'
+            metatag_trash_command = "feed my #{item} to gelapod" if DRRoom.room_objs.include?('gelapod')
+          else
+            metatag_trash_command = "put my #{item} in #{metatag_trashcan}"
+          end
+
+          # gelapod is not here - probably winter move on to next attempt to get rid of
+          unless metatag_trash_command.nil?
+            case DRC.bput(metatag_trash_command, DROP_TRASH_SUCCESS_PATTERNS, DROP_TRASH_FAILURE_PATTERNS, DROP_TRASH_RETRY_PATTERNS, /^Perhaps you should be holding that first/)
+            when *DROP_TRASH_SUCCESS_PATTERNS
+              return true
+            when *DROP_TRASH_FAILURE_PATTERNS
+              # NOOP, try next trashcan option
+            when *DROP_TRASH_RETRY_PATTERNS
+              # If still didn't dispose of trash after retry
+              # then don't return yet, will try to drop it later.
+              return dispose_trash(item)
+            when /^Perhaps you should be holding that first/
+              return (DRCI.get_item?(item) && DRCI.dispose_trash(item))
+            end
           end
         end
 
@@ -474,26 +505,31 @@ module Lich
           trash_command = "put my #{item} in #{trashcan}" unless trashcan == 'gelapod'
 
           case DRC.bput(trash_command, DROP_TRASH_SUCCESS_PATTERNS, DROP_TRASH_FAILURE_PATTERNS, DROP_TRASH_RETRY_PATTERNS, /^Perhaps you should be holding that first/)
-          when /^Perhaps you should be holding that first/
-            return (DRCI.get_item?(item) && DRCI.dispose_trash(item))
+          when *DROP_TRASH_SUCCESS_PATTERNS
+            return true
+          when *DROP_TRASH_FAILURE_PATTERNS
+            # NOOP, try next trashcan option
           when *DROP_TRASH_RETRY_PATTERNS
             # If still didn't dispose of trash after retry
             # then don't return yet, will try to drop it later.
             return true if dispose_trash(item)
-          when *DROP_TRASH_SUCCESS_PATTERNS
-            return true
+          when /^Perhaps you should be holding that first/
+            return (DRCI.get_item?(item) && DRCI.dispose_trash(item))
           end
         end
 
         # No trash bins or not able to put item in a bin, just drop it.
         case DRC.bput("drop my #{item}", DROP_TRASH_SUCCESS_PATTERNS, DROP_TRASH_FAILURE_PATTERNS, DROP_TRASH_RETRY_PATTERNS, /^Perhaps you should be holding that first/, /^But you aren't holding that/)
-        when /^Perhaps you should be holding that first/, /^But you aren't holding that/
-          return (DRCI.get_item?(item) && DRCI.dispose_trash(item))
-        when *DROP_TRASH_RETRY_PATTERNS
-          return dispose_trash(item)
         when *DROP_TRASH_SUCCESS_PATTERNS
           return true
+        when *DROP_TRASH_FAILURE_PATTERNS
+          return false
+        when *DROP_TRASH_RETRY_PATTERNS
+          return dispose_trash(item)
+        when /^Perhaps you should be holding that first/, /^But you aren't holding that/
+          return (DRCI.get_item?(item) && DRCI.dispose_trash(item))
         else
+          # failure of match patterns in the bput, but still need to return a value
           return false
         end
       end


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Enhanced `dispose_trash` in `common-items.rb` to handle `meta:trashcan` tags, reorder case patterns, and improve trashcan selection logic.
> 
>   - **Behavior**:
>     - Enhanced `dispose_trash` in `common-items.rb` to handle `meta:trashcan` room tags, allowing specific trashcan usage.
>     - Added special handling for `gelapod` trashcan, including seasonal availability checks.
>     - Reordered case patterns in `dispose_trash` to prioritize success and failure patterns over retry patterns.
>   - **Logic**:
>     - Improved logic for selecting trashcan types based on room objects, including specific handling for `gloop`, `bucket`, `basket`, `bin`, `arms`, `birdbath`, `turtle`, `tree`, `basin`, and `tangle`.
>     - Added fallback logic to drop items if no trashcan is available or usable.
>   - **Misc**:
>     - Minor refactoring for clarity and efficiency in `dispose_trash` function.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Lich5%2Fng-betalich&utm_source=github&utm_medium=referral)<sup> for 9133af6f6b1b80beae166969ade50f2cb010406d. You can [customize](https://app.ellipsis.dev/Lich5/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->