### PR TITLE
chore(all): update exclusionso and reduce noise from CI

### DIFF
--- a/.github/workflows/format-release-notes.yaml
+++ b/.github/workflows/format-release-notes.yaml
@@ -115,7 +115,7 @@ jobs:
 
       # Robust PR lookup for the Release Please PR that produced this tag.
       - name: Find merged Release Please PR for this tag
-        if: steps.guard.outputs.skip != 'true'
+        if: steps.seed.outputs.skip != 'true' && steps.guard.outputs.skip != 'true'
         id: findpr
         uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b
         env:
@@ -173,7 +173,7 @@ jobs:
 
       # Read PR body only when found.
       - name: Read PR body (seed text)
-        if: steps.guard.outputs.skip != 'true' && steps.findpr.outputs.found == 'true'
+        if: steps.seed.outputs.skip != 'true' && steps.guard.outputs.skip != 'true' && steps.findpr.outputs.found == 'true'
         id: readpr
         uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b
         env:
@@ -188,7 +188,7 @@ jobs:
 
       # Choose the source body (PR body when present; else release body). No heredoc.
       - name: Choose seed body
-        if: steps.guard.outputs.skip != 'true'
+        if: steps.seed.outputs.skip != 'true' && steps.guard.outputs.skip != 'true'
         id: choose
         uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b
         env:
@@ -201,7 +201,7 @@ jobs:
             core.setOutput('body', prb || rel);
 
       - name: Transform body (normalize header, drop RP/Ellipsis, plain PR refs, append footer + sentinel)
-        if: steps.guard.outputs.skip != 'true'
+        if: steps.seed.outputs.skip != 'true' && steps.guard.outputs.skip != 'true'
         id: transform
         uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b
         env:
@@ -257,7 +257,7 @@ jobs:
             core.setOutput('final', body);
 
       - name: Update release title (Lich v{version})
-        if: steps.guard.outputs.skip != 'true'
+        if: steps.seed.outputs.skip != 'true' && steps.guard.outputs.skip != 'true'
         uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b
         env:
           RELEASE_ID: ${{ steps.seed.outputs.release_id }}
@@ -276,7 +276,7 @@ jobs:
             }
 
       - name: Update release body
-        if: steps.guard.outputs.skip != 'true'
+        if: steps.seed.outputs.skip != 'true' && steps.guard.outputs.skip != 'true'
         uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b
         env:
           RELEASE_ID: ${{ steps.seed.outputs.release_id }}
@@ -291,3 +291,7 @@ jobs:
       - name: Already formatted (noop)
         if: steps.guard.outputs.skip == 'true'
         run: echo "Release body already contains channel-specific sentinel; skipping."
+
+- name: No release to format (noop)
+  if: steps.seed.outputs.skip == 'true'
+  run: echo "No release resolved (zero releases or upstream didn't publish); formatter exiting cleanly."

--- a/.github/workflows/release-on-push-stable.yaml
+++ b/.github/workflows/release-on-push-stable.yaml
@@ -5,6 +5,16 @@ on:
     branches: [ main ]
     paths-ignore:
       - '.github/workflows/**'
+      - '.github/actions/**'
+      - 'spec/**'
+      - '.gitattributes'
+      - '.gitignore'
+      - '.rubocop.yml'
+      - '.ruby-version'
+      - 'netlify.toml'
+      - 'README.adoc'
+      - 'release-please-config.json'
+      - 'release-please-config.prerelease.json'
 
 permissions:
   contents: write


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Update GitHub Actions workflows to reduce noise by adding conditions and expanding path exclusions.
> 
>   - **GitHub Actions**:
>     - In `format-release-notes.yaml`, added `steps.seed.outputs.skip != 'true'` condition to multiple steps to ensure they only run when appropriate.
>     - Added a new step "No release to format (noop)" to handle cases where no release is resolved.
>   - **Path Exclusions**:
>     - Updated `release-on-push-stable.yaml` to ignore additional paths such as `.github/actions/**`, `spec/**`, `.gitattributes`, `.gitignore`, `.rubocop.yml`, `.ruby-version`, `netlify.toml`, `README.adoc`, `release-please-config.json`, and `release-please-config.prerelease.json`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Lich5%2Fng-betalich&utm_source=github&utm_medium=referral)<sup> for 07e0a775e674a89228fc213e955741d75b8dde34. You can [customize](https://app.ellipsis.dev/Lich5/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->