### PR TITLE
chore(all): indentation error correction format-release-notes workflow

### DIFF
--- a/.github/workflows/format-release-notes.yaml
+++ b/.github/workflows/format-release-notes.yaml
@@ -292,6 +292,6 @@ jobs:
         if: steps.guard.outputs.skip == 'true'
         run: echo "Release body already contains channel-specific sentinel; skipping."
 
-- name: No release to format (noop)
-  if: steps.seed.outputs.skip == 'true'
-  run: echo "No release resolved (zero releases or upstream didn't publish); formatter exiting cleanly."
+      - name: No release to format (noop)
+        if: steps.seed.outputs.skip == 'true'
+        run: echo "No release resolved (zero releases or upstream didn't publish); formatter exiting cleanly."


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Corrects indentation error in `format-release-notes.yaml` workflow file.
> 
>   - **Fixes**:
>     - Corrects indentation error in `.github/workflows/format-release-notes.yaml` for the `No release to format (noop)` step.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Lich5%2Fng-betalich&utm_source=github&utm_medium=referral)<sup> for 96376e00610dbb4133cba7984e641c76e5f1f07b. You can [customize](https://app.ellipsis.dev/Lich5/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->