### PR TITLE
chore(all): hardened prepare-stable-release PR workflow

### DIFF
--- a/.github/workflows/prepare-stable-release.yaml
+++ b/.github/workflows/prepare-stable-release.yaml
@@ -1,4 +1,8 @@
 name: Prepare Stable Release
+# Purpose: Open/update the Release Please PR on the stable trunk (main).
+# Notes:
+#  - Tag + GitHub Release occur when the PR is merged.
+#  - Hardened to prevent foot-guns; no prerelease (beta) train logic here.
 on:
   workflow_dispatch:
     inputs:
@@ -6,28 +10,90 @@ on:
         description: "Branch to release from"
         required: true
         default: "main"
+  # Future: also trigger automatically when main changes (uncomment when ready).
+  # this may be problematic and requires rigorous testing
+  # push:
+  #   branches: [ "main" ]
 
 permissions:
   contents: write
   pull-requests: write
+  issues: write
 
 concurrency:
-  group: release-pr-stable-${{ github.ref }}
-  cancel-in-progress: false
+  group: prepare-stable-${{ github.event_name }}-${{ inputs.target_branch || 'main' }}
+  cancel-in-progress: true
 
 jobs:
   stable:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+      - name: "Guard: require main as target"
+        shell: bash
+        env:
+          RAW_TARGET: ${{ inputs.target_branch }}
+        run: |
+          set -euo pipefail
+          tgt="${RAW_TARGET:-}"
+          tgt="${tgt#refs/heads/}"
+          tgt="${tgt//[[:space:]]/}"
+          if [ "$tgt" != "main" ]; then
+            echo "::error::Stable releases must be prepared from 'main' (got '$tgt')."
+            exit 1
+          fi
+
+      - name: Checkout
+        # Pinned to SHA for supply-chain safety (actions/checkout v5.0.0)
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
         with:
           ref: ${{ inputs.target_branch }}
           fetch-depth: 0
 
+      - name: Git LF config (stabilize EOL)
+        run: |
+          git config --global core.autocrlf false
+          git config --global core.eol lf
+
+      - name: GITHUB_TOKEN write self-test (labels)
+        if: always()
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          repo="${{ github.repository }}"
+          lbl="rp-selftest-${{ github.run_id }}"
+          gh api -X POST "/repos/$repo/labels"             -f name="$lbl" -f color=ededed -f description="release-please token self-test"
+          gh api -X DELETE "/repos/$repo/labels/$lbl"
+
+      # Only proceed if releasable units exist since last stable tag.
+      # Releasable units for this repo: feat|fix with scope (all|dr|gs).
+      - name: "Guard: detect releasable units since last stable tag"
+        shell: bash
+        run: |
+          set -euo pipefail
+          git fetch --tags --force
+          last="$(git tag -l 'v[0-9]*.[0-9]*.[0-9]*' --sort=-version:refname | head -n1 || true)"
+          range="${last:+$last..}HEAD"
+          echo "Last stable tag: ${last:-<none>}"
+          if [ -n "$last" ]; then
+            rel="$(git log --pretty=%s "$range" | grep -E '^(feat|fix)\((all|dr|gs)\):' || true)"
+          else
+            rel="$(git log --pretty=%s | grep -E '^(feat|fix)\((all|dr|gs)\):' || true)"
+          fi
+          if [ -z "$rel" ]; then
+            echo "::notice::No releasable units (feat/fix with scope all|dr|gs) since ${last:-repo start}; skipping Release Please."
+            exit 0
+          fi
+
       - name: Release Please (open/update Release PR)
-        uses: googleapis/release-please-action@c2a5a2bd6a758a0937f1ddb1e8950609867ed15c # v4.3.0
+        # Pinned to SHA for supply-chain safety (release-please-action v4.3.0)
+        uses: googleapis/release-please-action@c2a5a2bd6a758a0937f1ddb1e8950609867ed15c
         with:
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
           target-branch: ${{ inputs.target_branch }}
-          # This opens/updates the PR. The actual tag+GitHub Release happen when you merge that PR.
+
+      # PR body and Release body formatting are handled by:
+      #  - format-pr-body-stable.yml  (PR body)
+      #  - release-on-push-stable.yml + format-release-notes.yml (Release body)
+      # This workflow intentionally does not format bodies.

--- a/.github/workflows/prepare-stable-release.yaml
+++ b/.github/workflows/prepare-stable-release.yaml
@@ -68,6 +68,7 @@ jobs:
       # Only proceed if releasable units exist since last stable tag.
       # Releasable units for this repo: feat|fix with scope (all|dr|gs).
       - name: "Guard: detect releasable units since last stable tag"
+        id: guard
         shell: bash
         run: |
           set -euo pipefail
@@ -81,11 +82,15 @@ jobs:
             rel="$(git log --pretty=%s | grep -E '^(feat|fix)\((all|dr|gs)\):' || true)"
           fi
           if [ -z "$rel" ]; then
+            echo "has_releasables=false" >> "$GITHUB_OUTPUT"
             echo "::notice::No releasable units (feat/fix with scope all|dr|gs) since ${last:-repo start}; skipping Release Please."
             exit 0
+          else
+            echo "has_releasables=true" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Release Please (open/update Release PR)
+        if: ${{ steps.guard.outputs.has_releasables == 'true' }}
         # Pinned to SHA for supply-chain safety (release-please-action v4.3.0)
         uses: googleapis/release-please-action@c2a5a2bd6a758a0937f1ddb1e8950609867ed15c
         with:


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Enhances `prepare-stable-release.yaml` workflow with branch guards, releasable unit checks, and GitHub token self-test.
> 
>   - **Workflow Enhancements**:
>     - Adds guard to ensure releases are prepared from `main` branch in `prepare-stable-release.yaml`.
>     - Introduces check for releasable units (feat/fix with scope all|dr|gs) since last stable tag.
>     - Adds GitHub token write self-test for label creation and deletion.
>   - **Configuration**:
>     - Updates concurrency group to `prepare-stable-${{ github.event_name }}-${{ inputs.target_branch || 'main' }}` and enables `cancel-in-progress`.
>     - Configures Git LF to stabilize EOL settings.
>   - **Misc**:
>     - Adds comments for future automatic triggering on `main` changes.
>     - Updates notes and comments for clarity on workflow purpose and behavior.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Lich5%2Fng-betalich&utm_source=github&utm_medium=referral)<sup> for b78d27e4e5f4f6ae5a906bb68138d852f52bf888. You can [customize](https://app.ellipsis.dev/Lich5/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->