### PR TITLE
chore(all): add PR formatter for stable PRs

### DIFF
--- a/.github/workflows/format-pr-body-stable.yaml
+++ b/.github/workflows/format-pr-body-stable.yaml
@@ -1,0 +1,37 @@
+name: Format Release PR Body (Stable)
+
+on:
+  pull_request:
+    types: [opened, labeled, synchronize, edited, reopened]
+    branches:
+      - "main"
+  # Manual escape hatch
+  # workflow_dispatch: {}
+
+permissions:
+  pull-requests: write
+  contents: read
+
+concurrency:
+  group: format-body-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  format:
+    if: |
+      (github.event.pull_request.user.login == 'release-please[bot]' ||
+       github.event.pull_request.user.login == 'github-actions[bot]') &&
+      contains(join(github.event.pull_request.labels.*.name, ','), 'autorelease: pending') &&
+      github.event.pull_request.base.ref == 'main'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout (read optional sections.md if present)
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955
+
+      - name: Format body (stable, idempotent)
+        uses: ./.github/actions/format-body
+        with:
+          mode: stable
+          wait_seconds: 0
+          wait_interval_seconds: 5
+


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds a GitHub Actions workflow to format PR bodies for stable releases under specific conditions.
> 
>   - **New Workflow**:
>     - Adds `format-pr-body-stable.yaml` to `.github/workflows/` to format PR bodies for stable releases.
>     - Triggers on `pull_request` events: opened, labeled, synchronize, edited, reopened on `main` branch.
>     - Includes manual trigger option with `workflow_dispatch`.
>   - **Permissions and Concurrency**:
>     - Grants `pull-requests: write` and `contents: read` permissions.
>     - Uses concurrency group `format-body-${{ github.event.pull_request.number }}` with `cancel-in-progress: true`.
>   - **Job Conditions**:
>     - Runs if PR is from `release-please[bot]` or `github-actions[bot]` and labeled `autorelease: pending`.
>     - Ensures PR base is `main`.
>   - **Steps**:
>     - Checks out repository using `actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955`.
>     - Formats PR body using `./.github/actions/format-body` with `mode: stable`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Lich5%2Fng-betalich&utm_source=github&utm_medium=referral)<sup> for 524c536bee85964baa97e4a51bc7aae3c8b4ad5a. You can [customize](https://app.ellipsis.dev/Lich5/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->