### PR TITLE
chore(all): update pr body format for stable PRs

### DIFF
--- a/.github/actions/format-body/action.yaml
+++ b/.github/actions/format-body/action.yaml
@@ -36,6 +36,10 @@ inputs:
     description: "pre | stable"
     required: true
     default: "pre"
+  pr_number:
+    description: "Explicit PR number (for workflow_run invocations)"
+    required: false
+    default: ""
   wait_seconds:
     description: "Max seconds to wait for Ellipsis block to appear"
     required: false
@@ -71,6 +75,7 @@ runs:
         WAIT_I: ${{ inputs.wait_interval_seconds }}
         CONTRACT_SHA: "95f8f517411f9058bc92706310677db8cbba97fbd296bc853f2181274cb0e8bb"
         BREAK_AUTO: ${{ inputs.break_autolinks_in_bullets }}
+        PR_NUMBER: ${{ inputs.pr_number }}
       with:
         script: |
           const MODE = process.env.MODE; // 'pre' or 'stable'
@@ -82,7 +87,12 @@ runs:
 
           const owner = context.repo.owner;
           const repo = context.repo.repo;
-          const prNumber = context.issue.number;
+          const explicit = (process.env.PR_NUMBER || "").trim();
+          const prNumber = explicit || (context.issue && context.issue.number);
+          if (!prNumber) {
+            core.setFailed("No PR context. Provide 'pr_number' when not running on pull_request.");
+            process.exit(1);
+          }
 
           const ELLIPSIS_MARK = '<!-- ELLIPSIS_HIDDEN -->';
 
@@ -254,10 +264,12 @@ runs:
         script: |
           const owner = context.repo.owner;
           const repo = context.repo.repo;
-          const pull_number = context.issue.number;
+          const pull_number = (process.env.PR_NUMBER || "").trim() || (context.issue && context.issue.number);
+          if (!pull_number) { core.setFailed("Missing PR number for PATCH."); process.exit(1); }
           const finalBody = process.env.finalBody;
           await github.rest.pulls.update({ owner, repo, pull_number, body: finalBody });
       env:
+        PR_NUMBER: ${{ inputs.pr_number }}
         finalBody: ${{ steps.compose.outputs.finalBody }}
 
     - name: Sentinel unchanged (skipped)

--- a/.github/workflows/format-pr-body-stable.yaml
+++ b/.github/workflows/format-pr-body-stable.yaml
@@ -5,6 +5,9 @@ on:
     types: [opened, labeled, synchronize, edited, reopened]
     branches:
       - "main"
+  workflow_run:
+    workflows: ["Prepare Stable Release"]
+    types: [completed]
   # Manual escape hatch
   # workflow_dispatch: {}
 
@@ -35,3 +38,36 @@ jobs:
           wait_seconds: 0
           wait_interval_seconds: 5
 
+
+  format_from_release_please_run:
+    if: >
+      github.event_name == 'workflow_run' &&
+      github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout (read optional sections.md if present)
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955
+
+      - name: Find open Release Please PR (stable)
+        id: find
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b
+        with:
+          script: |
+            const { owner, repo } = context.repo;
+            const all = await github.paginate(github.rest.pulls.list, {
+              owner, repo, state: 'open', base: 'main', sort: 'updated', direction: 'desc', per_page: 50
+            });
+            const match = all.find(pr =>
+              pr.user && (pr.user.login === 'release-please[bot]' || pr.user.login === 'github-actions[bot]') &&
+              pr.labels && pr.labels.some(l => l.name === 'autorelease: pending')
+            );
+            if (!match) core.setFailed('No open Release Please PR (stable) found.');
+            core.setOutput('number', String(match.number));
+
+      - name: Format body (stable via workflow_run)
+        uses: ./.github/actions/format-body
+        with:
+          mode: stable
+          wait_seconds: 0
+          wait_interval_seconds: 5
+          pr_number: ${{ steps.find.outputs.number }}


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Update GitHub Actions to format stable PR bodies using `workflow_run` events and explicit PR numbers.
> 
>   - **GitHub Actions**:
>     - Add `pr_number` input to `format-body/action.yaml` for explicit PR number handling.
>     - Modify `format-pr-body-stable.yaml` to support `workflow_run` events from 'Prepare Stable Release'.
>     - Add `format_from_release_please_run` job to handle stable PR formatting via `workflow_run`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Lich5%2Fng-betalich&utm_source=github&utm_medium=referral)<sup> for f33c206a6f64c44a3523ad08b740cbb006276698. You can [customize](https://app.ellipsis.dev/Lich5/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->