### PR TITLE
chore(all): gating and renaming jobs for sanity

### DIFF
--- a/.github/workflows/format-pr-body-stable.yaml
+++ b/.github/workflows/format-pr-body-stable.yaml
@@ -21,7 +21,9 @@ concurrency:
 
 jobs:
   format:
+    name: format pr body on request
     if: |
+      github.event_name == 'pull_request' &&
       (github.event.pull_request.user.login == 'release-please[bot]' ||
        github.event.pull_request.user.login == 'github-actions[bot]') &&
       contains(join(github.event.pull_request.labels.*.name, ','), 'autorelease: pending') &&
@@ -40,6 +42,7 @@ jobs:
 
 
   format_from_release_please_run:
+    name: format pr body on workflow complete
     if: >
       github.event_name == 'workflow_run' &&
       github.event.workflow_run.conclusion == 'success'

--- a/.github/workflows/format-pr-body-stable.yaml
+++ b/.github/workflows/format-pr-body-stable.yaml
@@ -1,3 +1,23 @@
+## -----------------------------------------------------------------------------
+## Format Release PR Body (Stable) — Documentation
+##
+## Why two triggers:
+## - pull_request path handles human edits/labels to the Release Please PR.
+## - workflow_run path handles when Release Please updates the PR using GITHUB_TOKEN,
+##   which does not emit pull_request events. Chaining off the upstream workflow
+##   restores deterministic formatting after RP updates.
+##
+## Block scalars for `if:`:
+## - Prefer the folded scalar (>) for multi-line expressions because GitHub's `if:`
+##   expects a single string. The literal scalar (|) preserves newlines and can be
+##   more brittle. If you keep (|) for readability, ensure the expression remains
+##   valid across newlines.
+##
+## Wait behavior:
+## - The composite action's default wait_seconds is 60s, but workflows pass 0 here
+##   for fast feedback (no polling for Ellipsis). The workflow input overrides the
+##   action default.
+## -----------------------------------------------------------------------------
 name: Format Release PR Body (Stable)
 
 on:
@@ -21,8 +41,15 @@ concurrency:
 
 jobs:
   format:
-    name: format pr body on request
-    if: |
+    # Job: Format PR Body on Pull Request
+    # Scope: Runs only on pull_request events (never on workflow_run).
+    # Guards:
+    #   - Confines to the Release Please PR (RP bot author + 'autorelease: pending' label + base 'main').
+    # Block scalar note:
+    #   - Prefer (>) for multi-line `if:`; (|) preserves newlines and is more fragile.
+    name: Format PR Body on Pull Request
+    # Keep the pull_request gate first so this job does not evaluate on workflow_run.
+    if: >
       github.event_name == 'pull_request' &&
       (github.event.pull_request.user.login == 'release-please[bot]' ||
        github.event.pull_request.user.login == 'github-actions[bot]') &&
@@ -37,12 +64,17 @@ jobs:
         uses: ./.github/actions/format-body
         with:
           mode: stable
-          wait_seconds: 0
+          wait_seconds: 0   # Override action default (60s). 0 = no polling for Ellipsis; fastest feedback.
           wait_interval_seconds: 5
 
 
   format_from_release_please_run:
-    name: format pr body on workflow complete
+    # Job: Format PR Body on Workflow Complete
+    # Why: Release Please updates the PR using GITHUB_TOKEN, which does not emit
+    #      pull_request events. This job chains off the upstream workflow completion
+    #      as a reliable signal to re-format the open RP PR.
+    name: Format PR Body on Workflow Complete
+    # Gate strictly to successful workflow_run events from "Prepare Stable Release".
     if: >
       github.event_name == 'workflow_run' &&
       github.event.workflow_run.conclusion == 'success'
@@ -52,6 +84,11 @@ jobs:
         uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955
 
       - name: Find open Release Please PR (stable)
+      # Criteria:
+      #   - Base branch is main
+      #   - Label 'autorelease: pending'
+      #   - Author is RP bot (release-please[bot] or github-actions[bot])
+      # Adjust here if your labeling/authoring conventions change.
         id: find
         uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b
         with:
@@ -71,6 +108,6 @@ jobs:
         uses: ./.github/actions/format-body
         with:
           mode: stable
-          wait_seconds: 0
+          wait_seconds: 0   # Override action default (60s). 0 = no polling for Ellipsis; fastest feedback.
           wait_interval_seconds: 5
           pr_number: ${{ steps.find.outputs.number }}


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Improves GitHub workflow for formatting release PR bodies by renaming jobs, adding gating, and enhancing conditions for clarity and efficiency.
> 
>   - **Jobs and Conditions**:
>     - Renames jobs in `format-pr-body-stable.yaml` for clarity: `format` to `Format PR Body on Pull Request` and `format_from_release_please_run` to `Format PR Body on Workflow Complete`.
>     - Adds detailed comments explaining job triggers and conditions.
>     - Updates `if` conditions to use folded scalars (>) for multi-line expressions for better readability and reliability.
>   - **Behavior**:
>     - Ensures `Format PR Body on Pull Request` runs only on `pull_request` events with specific conditions (RP bot author, 'autorelease: pending' label, base 'main').
>     - Ensures `Format PR Body on Workflow Complete` runs only on successful `workflow_run` events from "Prepare Stable Release".
>   - **Misc**:
>     - Overrides `wait_seconds` to 0 for faster feedback in both jobs.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Lich5%2Fng-betalich&utm_source=github&utm_medium=referral)<sup> for 3eb7d7a880c1f62253da3eaba3c251fd05ecf412. You can [customize](https://app.ellipsis.dev/Lich5/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->