### PR TITLE
chore(all): Tysong broke it! Enforce repo for gh release edit

### DIFF
--- a/.github/workflows/release-on-push-stable.yaml
+++ b/.github/workflows/release-on-push-stable.yaml
@@ -34,6 +34,11 @@ on:
       - 'README.adoc'
       - 'release-please-config.json'
       - 'release-please-config.prerelease.json'
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Existing tag to (re)format"
+        required: true
 
 permissions:
   contents: write
@@ -269,6 +274,7 @@ jobs:
 
     outputs:
       installer: ${{ steps.gate.outputs.installer }}
+
   build_installer:
     needs: [release, installer_gate]
     if: ${{ needs.release.outputs.release_created == 'true' && needs.installer_gate.outputs.installer == 'true' }}
@@ -564,3 +570,129 @@ jobs:
         shell: bash
         run: |
           gh release upload "${{ needs.release.outputs.tag_name }}" Ruby4Lich5.exe
+
+  # ---------------------------------------------------------------------------
+  # BEGIN TEMPORARY: Manual repair path for existing releases (easily removable)
+  manual_repair_existing_release:
+    name: manual repair: format release body for existing tag
+    if: github.event_name == 'workflow_dispatch'
+    permissions:
+      contents: write
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - name: Derive release vars from tag (manual)
+        id: derive_rel_manual
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b
+        env:
+          TAG: ${{ github.event.inputs.tag }}
+        with:
+          script: |
+            const tag = (process.env.TAG || '').trim();
+            if (!tag) core.setFailed('Missing tag input');
+            const m = tag.match(/(\d+\.\d+\.\d+(?:-[0-9A-Za-z.\-]+)?)/);
+            const version = m ? m[1] : '';
+            core.setOutput('version', version);
+            core.setOutput('published_at', new Date().toISOString());
+
+      - name: Find merged Release Please PR for this tag (manual)
+        id: find_pr_manual
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b
+        env:
+          VERSION: ${{ steps.derive_rel_manual.outputs.version }}
+          BASE: main
+        with:
+          script: |
+            const owner = context.repo.owner;
+            const repo  = context.repo.repo;
+            const rawVersion = process.env.VERSION || '';
+            const base = process.env.BASE || 'main';
+            const esc = s => s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+            const v = esc(rawVersion);
+            const titleRe = new RegExp(`\\b(?:release|Lich)\\s+v?${v}\\b`, 'i');
+            async function listClosed(opts) {
+              const r = await github.rest.pulls.list({ owner, repo, per_page: 100, sort: 'updated', direction: 'desc', ...opts });
+              return r.data || [];
+            }
+            let pulls = await listClosed({ base });
+            let hit = (pulls || []).find(pr => pr.merged_at && titleRe.test(pr.title || ''));
+            if (!hit) {
+              const q = `repo:${owner}/${repo} is:pr is:merged in:title "v${rawVersion}" base:${base}`;
+              try {
+                const search = await github.rest.search.issuesAndPullRequests({ q, per_page: 5, sort: 'updated', order: 'desc' });
+                const item = (search.data.items || [])[0];
+                if (item) {
+                  const pr = await github.rest.pulls.get({ owner, repo, pull_number: item.number });
+                  hit = pr.data;
+                }
+              } catch {}
+            }
+            core.setOutput('found', hit ? 'true' : 'false');
+            if (hit) core.setOutput('number', String(hit.number));
+
+      - name: Read PR body (seed) (manual)
+        if: ${{ steps.find_pr_manual.outputs.found == 'true' }}
+        id: read_pr_manual
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b
+        env:
+          NUMBER: ${{ steps.find_pr_manual.outputs.number }}
+        with:
+          script: |
+            const owner = context.repo.owner;
+            const repo  = context.repo.repo;
+            const number = parseInt(process.env.NUMBER || '0', 10);
+            const pr = await github.rest.pulls.get({ owner, repo, pull_number: number }).then(r => r.data);
+            core.setOutput('body', pr.body || '');
+
+      - name: Choose seed body (PR preferred) (manual)
+        id: choose_seed_manual
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b
+        env:
+          PR_BODY: ${{ steps.read_pr_manual.outputs.body }}
+        with:
+          script: |
+            const prb = process.env.PR_BODY || '';
+            core.setOutput('body', prb);
+
+      - name: Transform body (header + cleanup + footer) (manual)
+        id: transform_body_manual
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b
+        env:
+          SEED: ${{ steps.choose_seed_manual.outputs.body }}
+          VERSION: ${{ steps.derive_rel_manual.outputs.version }}
+          PUBLISHED_AT: ${{ steps.derive_rel_manual.outputs.published_at }}
+        with:
+          script: |
+            const seed = process.env.SEED || '';
+            const version = process.env.VERSION || '';
+            const dt = process.env.PUBLISHED_AT ? new Date(process.env.PUBLISHED_AT) : new Date();
+            const yyyy = dt.getUTCFullYear();
+            const mm = String(dt.getUTCMonth()+1).padStart(2,'0');
+            const dd = String(dt.getUTCDate()).padStart(2,'0');
+            const headerLine = `Lich v${version} (${yyyy}-${mm}-${dd})`;
+            const lines = seed.split(/\r?\n/);
+            let i = 0; while (i < lines.length && /^\s*$/.test(lines[i])) i++;
+            if (i >= lines.length) lines.push(headerLine); else lines[i] = headerLine;
+            let body = lines.join('\n');
+            body = body.replace(/\[#(\d+)\]\([^)]*\)/g, '#$1').trim();
+            const footer = [
+              '',
+              'For additional usage/install instructions, please visit one of the following:',
+              '',
+              'DragonRealms - https://github.com/elanthia-online/lich-5/wiki/Documentation-for-Installing-and-Upgrading-Lich',
+              'Gemstone IV - https://gswiki.play.net/Lich:Software/Installation'
+            ].join('\n');
+            body = body.replace(/\n+$/, '') + '\n' + footer + '\n';
+            core.setOutput('final', body);
+
+      - name: Apply title/body to release (gh) (manual)
+        env:
+          TAG: ${{ github.event.inputs.tag }}
+          VERSION: ${{ steps.derive_rel_manual.outputs.version }}
+          FINAL: ${{ steps.transform_body_manual.outputs.final }}
+        run: |
+          set -euo pipefail
+          gh release edit -R "$GITHUB_REPOSITORY" "$TAG" --title "Lich v$VERSION" --notes-file <(printf '%s' "$FINAL")
+  # END TEMPORARY: Manual repair path
+  # ---------------------------------------------------------------------------

--- a/.github/workflows/release-on-push-stable.yaml
+++ b/.github/workflows/release-on-push-stable.yaml
@@ -189,7 +189,7 @@ jobs:
           FINAL: ${{ steps.transform_body.outputs.final }}
         run: |
           set -euo pipefail
-          gh release edit "$TAG" --title "Lich v$VERSION" --notes-file <(printf '%s' "$FINAL")
+          gh release edit -R "$GITHUB_REPOSITORY" "$TAG" --title "Lich v$VERSION" --notes-file <(printf '%s' "$FINAL")
       # --- END FAST-PATH ---
 
       # 2) Only build/upload when a new GitHub Release was created


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Enhances GitHub Actions workflow with manual release formatting and repository enforcement in `release-on-push-stable.yaml`.
> 
>   - **GitHub Actions Workflow**:
>     - Adds `workflow_dispatch` event to `release-on-push-stable.yaml` for manual release formatting.
>     - Ensures `gh release edit` command specifies `-R "$GITHUB_REPOSITORY"` to enforce repository context.
>   - **Manual Repair Path**:
>     - Introduces `manual_repair_existing_release` job for formatting release body of existing tags.
>     - Uses `actions/github-script` to derive release variables, find PRs, and transform release body.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Lich5%2Fng-betalich&utm_source=github&utm_medium=referral)<sup> for f6ecd40a581edd8977f7753c293f1b3ac80e4e35. You can [customize](https://app.ellipsis.dev/Lich5/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->