### PR TITLE
chore(all): And Tysong broke it! Remove toolchain spec from InnoSetup

### DIFF
--- a/.github/workflows/release-on-push-prerelease.yaml
+++ b/.github/workflows/release-on-push-prerelease.yaml
@@ -657,13 +657,15 @@ jobs:
       # Build Windows installer with Inno Setup
       - name: Build Windows installer with Inno Setup
         shell: powershell
-        env:
-          PATH: ${{ steps.vendormsys.outputs.path }}
-          RI_DEVKIT: ''
         run: |
           $iscc = "${env:ProgramFiles(x86)}\Inno Setup 6\ISCC.exe"
           if (!(Test-Path $iscc)) { Write-Error "ISCC.exe not found at $iscc"; exit 1 }
           & $iscc "R4LGTK3.iss"
+          $code = $LASTEXITCODE
+          if ($code -ne 0) {
+            Write-Error "ISCC exited with code $code (likely missing SignTool or another PATH-dependent tool)."
+            exit $code
+          }
           if (!(Test-Path .\Output\Ruby4Lich5.exe)) { Write-Error "Expected Output\Ruby4Lich5.exe not found"; exit 1 }
           Move-Item -Path .\Output\Ruby4Lich5.exe -Destination .\Ruby4Lich5.exe -Force
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Remove toolchain spec and add error handling for Inno Setup in `release-on-push-prerelease.yaml`.
> 
>   - **Workflow Changes**:
>     - In `release-on-push-prerelease.yaml`, remove `PATH` and `RI_DEVKIT` from environment variables for the Inno Setup build step.
>     - Add error handling for ISCC execution, logging an error if ISCC exits with a non-zero code and exiting with the same code.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Lich5%2Fng-betalich&utm_source=github&utm_medium=referral)<sup> for c753ed5fdf8a2e393729803d30291654cae0ca7c. You can [customize](https://app.ellipsis.dev/Lich5/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->