### PR TITLE
chore(all): And in before Tysong breaks this one! Installer builder i…

### DIFF
--- a/.github/workflows/release-on-push-stable.yaml
+++ b/.github/workflows/release-on-push-stable.yaml
@@ -551,16 +551,18 @@ jobs:
           unzip -q lich-5.zip
           # Archive contains Lich5/ (capital L) to match the .iss Source paths
 
-      # Build Windows installer with Inno Setup
+     # Build Windows installer with Inno Setup
       - name: Build Windows installer with Inno Setup
         shell: powershell
-        env:
-          PATH: ${{ steps.vendormsys.outputs.path }}
-          RI_DEVKIT: ''
         run: |
           $iscc = "${env:ProgramFiles(x86)}\Inno Setup 6\ISCC.exe"
           if (!(Test-Path $iscc)) { Write-Error "ISCC.exe not found at $iscc"; exit 1 }
           & $iscc "R4LGTK3.iss"
+          $code = $LASTEXITCODE
+          if ($code -ne 0) {
+            Write-Error "ISCC exited with code $code (likely missing SignTool or another PATH-dependent tool)."
+            exit $code
+          }
           if (!(Test-Path .\Output\Ruby4Lich5.exe)) { Write-Error "Expected Output\Ruby4Lich5.exe not found"; exit 1 }
           Move-Item -Path .\Output\Ruby4Lich5.exe -Destination .\Ruby4Lich5.exe -Force
 


### PR DESCRIPTION
…n stable release
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds error handling for Inno Setup Compiler execution in `release-on-push-stable.yaml` workflow.
> 
>   - **Workflow**:
>     - Updates `release-on-push-stable.yaml` to add error handling for Inno Setup Compiler (ISCC) execution.
>     - Checks `$LASTEXITCODE` after ISCC execution and logs error if non-zero, indicating potential PATH issues.
>     - Ensures `Ruby4Lich5.exe` is moved to the correct destination if present.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Lich5%2Fng-betalich&utm_source=github&utm_medium=referral)<sup> for 78e7b13fbbacdc046d9c154b33d759a4394c6a8e. You can [customize](https://app.ellipsis.dev/Lich5/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->