### PR TITLE
chore(all): add pin audit workflow and change release notes concurrency

### DIFF
--- a/.github/workflows/format-release-notes.yaml
+++ b/.github/workflows/format-release-notes.yaml
@@ -1,5 +1,9 @@
 name: format-release-notes
 
+concurrency:
+  group: format-release-notes-${{ github.event.release.tag_name || github.run_id }}
+  cancel-in-progress: true
+
 on:
   # Fires on publish/edit of a release in the UI (not suppressed), for prerelease and stable.
   release:
@@ -19,10 +23,6 @@ on:
         description: "Release tag to format (e.g., v5.13.0-beta.0). Optional; without it we use latest stable."
         required: false
         type: string
-
-concurrency:
-  group: format-release-${{ github.run_id }}
-  cancel-in-progress: false
 
 jobs:
   format:

--- a/.github/workflows/pin-audit.yaml
+++ b/.github/workflows/pin-audit.yaml
@@ -1,0 +1,61 @@
+name: Pin Audit (actions uses)
+on:
+  workflow_dispatch:
+    inputs:
+      fail_on_find:
+        description: "Fail the job if any non-SHA refs are found"
+        required: false
+        default: "false"
+permissions:
+  contents: read
+jobs:
+  audit:
+    name: Scan workflow uses for non-SHA refs
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
+      - name: Scan for non-SHA refs
+        id: scan
+        shell: bash
+        run: |
+          set -euo pipefail
+          echo "Scanning .github/workflows and .github/actions for 'uses:' refs..."
+          # Collect YAML/action files
+          tmpfile="$(mktemp)"
+          find .github/workflows .github/actions -type f \
+            \( -iname '*.yml' -o -iname '*.yaml' -o -iname 'action.yml' -o -iname 'action.yaml' \) \
+            -print > "$tmpfile" || true
+          found=0
+          echo "### Pin Audit Results" >> "$GITHUB_STEP_SUMMARY"
+          while IFS= read -r f; do
+            while IFS= read -r line; do
+              # Extract the ref (text after '@') and ignore docker:// references
+              uses="$(echo "$line" | sed -E 's/^\s*uses:\s*//')"
+              ref="${uses##*@}"
+              if [[ "$uses" == docker://* ]]; then
+                continue
+              fi
+              # Skip local actions (./path)
+              if [[ "$uses" == ./* ]]; then
+                continue
+              fi
+              # Check if ref is a 40-char hex (SHA)
+              if [[ ! "$ref" =~ ^[0-9a-fA-F]{40}$ ]]; then
+                ((found++)) || true
+                printf '• %s: %s\n' "$f" "$uses" >> "$GITHUB_STEP_SUMMARY"
+              fi
+            done < <(grep -RnohE '^\s*uses:\s*[^#]+' "$f" || true)
+          done < "$tmpfile"
+          echo "non_sha_count=$found" >> "$GITHUB_OUTPUT"
+          if [[ "$found" -eq 0 ]]; then
+            echo "All remote actions appear SHA-pinned or local." >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "" >> "$GITHUB_STEP_SUMMARY"
+            echo "**Total non-SHA refs:** $found" >> "$GITHUB_STEP_SUMMARY"
+          fi
+      - name: Optionally fail on findings
+        if: ${{ steps.scan.outputs.non_sha_count != '0' && inputs.fail_on_find == 'true' }}
+        run: |
+          echo "Failing due to non-SHA refs per input flag."
+          exit 1

--- a/.github/workflows/pin-audit.yaml
+++ b/.github/workflows/pin-audit.yaml
@@ -20,6 +20,8 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
+          # Ensure temporary file is removed even on error/exit
+          trap '[[ -n "${tmpfile:-}" ]] && rm -f "$tmpfile"' EXIT
           echo "Scanning .github/workflows and .github/actions for 'uses:' refs..."
           # Collect YAML/action files
           tmpfile="$(mktemp)"


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Adds `pin-audit.yaml` for auditing non-SHA refs and updates concurrency in `format-release-notes.yaml`.
> 
>   - **Workflows**:
>     - Adds `pin-audit.yaml` to audit non-SHA refs in `.github/workflows` and `.github/actions`.
>     - Modifies `format-release-notes.yaml` to use a concurrency group based on release tag or run ID, enabling in-progress cancellations.
>   - **Behavior**:
>     - `pin-audit.yaml` scans for non-SHA refs and optionally fails if any are found, based on `fail_on_find` input.
>     - `format-release-notes.yaml` now cancels in-progress jobs if a new one starts with the same concurrency group.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Lich5%2Fng-betalich&utm_source=github&utm_medium=referral)<sup> for 7b33d36265368ee7ae01f13f1234b3b42cea303f. You can [customize](https://app.ellipsis.dev/Lich5/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->