### PR TITLE
chore(all): Make pin audit a bit more human useful

### DIFF
--- a/.github/workflows/pin-audit.yaml
+++ b/.github/workflows/pin-audit.yaml
@@ -10,12 +10,12 @@ permissions:
   contents: read
 jobs:
   audit:
-    name: Scan workflow uses for non-SHA refs
+    name: Scan workflow uses for pins and currency
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
-      - name: Scan for non-SHA refs
+      - name: Scan refs & check currency
         id: scan
         shell: bash
         run: |
@@ -28,34 +28,89 @@ jobs:
           find .github/workflows .github/actions -type f \
             \( -iname '*.yml' -o -iname '*.yaml' -o -iname 'action.yml' -o -iname 'action.yaml' \) \
             -print > "$tmpfile" || true
-          found=0
+
           echo "### Pin Audit Results" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+
+          non_sha=0
+          echo "#### Pinned SHA refs (currency check)" >> "$GITHUB_STEP_SUMMARY"
+          declare -A latest_tag latest_sha
+          while IFS= read -r f; do
+            # Find all uses: lines in the file
+            while IFS= read -r line; do
+              uses="$(echo "$line" | sed -E 's/^\s*uses:\s*//')"
+              # ignore docker://
+              [[ "$uses" == docker://* ]] && continue
+              # ignore local actions (./ or .github/)
+              [[ "$uses" == ./* || "$uses" == .github/* ]] && continue
+
+              owner_repo="${uses%@*}"
+              ref="${uses##*@}"
+
+              # If no '@' present (malformed), skip
+              [[ "$owner_repo" == "$uses" ]] && continue
+
+              # If not a SHA (40-hex), count as non-SHA (to be listed later) and skip currency check
+              if [[ ! "$ref" =~ ^[0-9a-fA-F]{40}$ ]]; then
+                ((non_sha++)) || true
+                continue
+              fi
+
+              # For SHA pins: determine latest semver tag in the action repo and compare
+              repo_url="https://github.com/${owner_repo}.git"
+              if [[ -z "${latest_tag[$owner_repo]:-}" ]]; then
+                # Fetch tags; prefer dereferenced '^{}' commit lines for annotated tags
+                mapfile -t tag_lines < <(git ls-remote --tags "$repo_url" 2>/dev/null | sed 's/\t/ /g')
+                # Build tag->commit map (prefer '^{}' lines)
+                declare -A tag_commit
+                for ln in "${tag_lines[@]}"; do
+                  sha="${ln%% *}"; refname="${ln##* }"
+                  [[ "$refname" != refs/tags/* ]] && continue
+                  tag="${refname#refs/tags/}"
+                  if [[ "$tag" =~ \^\{\}$ ]]; then
+                    base="${tag%^{}}"
+                    tag_commit["$base"]="$sha"
+                  elif [[ -z "${tag_commit[$tag]:-}" ]]; then
+                    tag_commit["$tag"]="$sha"
+                  fi
+                done
+                # Choose latest semver-like tag (vN or vN.N or vN.N.N), prefer those with dots
+                mapfile -t tags_sorted < <(printf '%s\n' "${!tag_commit[@]}" | grep -E '^v[0-9]+(\.[0-9]+){0,2}$' | sort -V)
+                if [[ "${#tags_sorted[@]}" -eq 0 ]]; then
+                  latest_tag[$owner_repo]="(no-tags)"
+                  latest_sha[$owner_repo]="$ref"
+                else
+                  latest="${tags_sorted[-1]}"
+                  latest_tag[$owner_repo]="$latest"
+                  latest_sha[$owner_repo]="${tag_commit[$latest]}"
+                fi
+              fi
+
+              # Compare our pin to the latest tag commit
+              if [[ "$ref" == "${latest_sha[$owner_repo]}" ]]; then
+                printf '• %s: %s — current at %s\n' "$f" "$uses" "${latest_tag[$owner_repo]}" >> "$GITHUB_STEP_SUMMARY"
+              else
+                printf '• %s: %s — new at %s\n' "$f" "$uses" "${latest_tag[$owner_repo]}" >> "$GITHUB_STEP_SUMMARY"
+              fi
+            done < <(grep -RnohE '^\s*uses:\s*[^#]+' "$f" || true)
+          done < "$tmpfile"
+
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "#### Non-SHA refs (excluding local and docker)" >> "$GITHUB_STEP_SUMMARY"
           while IFS= read -r f; do
             while IFS= read -r line; do
-              # Extract the ref (text after '@') and ignore docker:// references
               uses="$(echo "$line" | sed -E 's/^\s*uses:\s*//')"
+              # ignore docker:// and local
+              [[ "$uses" == docker://* || "$uses" == ./* || "$uses" == .github/* ]] && continue
               ref="${uses##*@}"
-              if [[ "$uses" == docker://* ]]; then
-                continue
-              fi
-              # Skip local actions (./path)
-              if [[ "$uses" == ./* ]]; then
-                continue
-              fi
-              # Check if ref is a 40-char hex (SHA)
               if [[ ! "$ref" =~ ^[0-9a-fA-F]{40}$ ]]; then
-                ((found++)) || true
                 printf '• %s: %s\n' "$f" "$uses" >> "$GITHUB_STEP_SUMMARY"
               fi
             done < <(grep -RnohE '^\s*uses:\s*[^#]+' "$f" || true)
           done < "$tmpfile"
-          echo "non_sha_count=$found" >> "$GITHUB_OUTPUT"
-          if [[ "$found" -eq 0 ]]; then
-            echo "All remote actions appear SHA-pinned or local." >> "$GITHUB_STEP_SUMMARY"
-          else
-            echo "" >> "$GITHUB_STEP_SUMMARY"
-            echo "**Total non-SHA refs:** $found" >> "$GITHUB_STEP_SUMMARY"
-          fi
+
+          echo "non_sha_count=$non_sha" >> "$GITHUB_OUTPUT"
+
       - name: Optionally fail on findings
         if: ${{ steps.scan.outputs.non_sha_count != '0' && inputs.fail_on_find == 'true' }}
         run: |


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Enhances pin audit workflow to check SHA pin currency and separate SHA/non-SHA outputs in `pin-audit.yaml`.
> 
>   - **Workflow Changes**:
>     - Updates job name in `pin-audit.yaml` from "Scan workflow uses for non-SHA refs" to "Scan workflow uses for pins and currency".
>     - Updates step name from "Scan for non-SHA refs" to "Scan refs & check currency".
>   - **Functionality**:
>     - Adds logic to check if SHA pins are current by comparing against the latest semver tag in the action repo.
>     - Separates output for pinned SHA refs and non-SHA refs in the GitHub step summary.
>     - Counts non-SHA references and outputs the count to `GITHUB_OUTPUT`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Lich5%2Fng-betalich&utm_source=github&utm_medium=referral)<sup> for 087a0b32c711477b205d4b93c230d7c258b76957. You can [customize](https://app.ellipsis.dev/Lich5/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->