### PR TITLE
chore(all): limit searches to recent PRs

### DIFF
--- a/.github/workflows/format-release-notes.yaml
+++ b/.github/workflows/format-release-notes.yaml
@@ -133,10 +133,10 @@ jobs:
             const titleRe = new RegExp(`\\b(?:release|Lich)\\s+v?${v}\\b`, 'i');
 
             async function listClosed(opts) {
-              return github.rest.pulls.list({ owner, repo, state: 'closed', per_page: 100, sort: 'updated', direction: 'desc', ...opts }).then(r => r.data || []);
+              return github.rest.pulls.list({ owner, repo, state: 'closed', per_page: 100, ...opts }).then(r => r.data || []);
             }
 
-            let pulls = await listClosed({ base });
+            let pulls = await listClosed({ base, head });
             let hit = (pulls || []).find(pr =>
               pr.merged_at &&
               titleRe.test(pr.title || '')

--- a/.github/workflows/release-on-push-stable.yaml
+++ b/.github/workflows/release-on-push-stable.yaml
@@ -104,15 +104,19 @@ jobs:
             const repo  = context.repo.repo;
             const rawVersion = process.env.VERSION || '';
             const base = process.env.BASE || 'main';
-            const esc = s => s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+
+            const head = `${owner}:release-please--branches--${base}`;const esc = s => s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
             const v = esc(rawVersion);
             const titleRe = new RegExp(`\\b(?:release|Lich)\\s+v?${v}\\b`, 'i');
             async function listClosed(opts) {
               const r = await github.rest.pulls.list({ owner, repo, per_page: 100, sort: 'updated', direction: 'desc', ...opts });
               return r.data || [];
             }
-            let pulls = await listClosed({ base });
-            let hit = (pulls || []).find(pr => pr.merged_at && titleRe.test(pr.title || ''));
+            let pulls = await listClosed({ base, head });
+            let hit = (pulls || [])
+              .filter(pr => pr.merged_at && titleRe.test(pr.title || ''))
+              .sort((a, b) => new Date(a.merged_at) - new Date(b.merged_at))
+              .pop();
             if (!hit) {
               const q = `repo:${owner}/${repo} is:pr is:merged in:title "v${rawVersion}" base:${base}`;
               try {
@@ -259,7 +263,7 @@ jobs:
           want=true
           gh_api() { gh api -H 'Accept: application/vnd.github+json' "$@"; }
           ver="$(printf '%s' "$tag" | sed -nE 's/.*([0-9]+\.[0-9]+\.[0-9]+(-[A-Za-z0-9.]+)?).*/\1/p')"
-          pulls_json="$(gh_api "/repos/$repo/pulls?state=closed&sort=updated&direction=desc&per_page=100")" || pulls_json="[]"
+          pulls_json="$(gh_api "/repos/$repo/pulls?state=closed&base=$branch&head=${repo%%/*}:release-please--branches--$branch&per_page=100")" || pulls_json="[]"
           best="$(printf '%s' "$pulls_json" | jq -r --arg v "$ver" '
             def esc: gsub("([.^$|()\[\]{}*+?\-])"; "\\$1");
             .[] | select(.merged_at != null)


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Limits pull request searches to recent ones by adding `head` parameter in GitHub workflow files, improving efficiency and accuracy.
> 
>   - **Behavior**:
>     - Limits pull request searches to recent ones by adding `head` parameter in `format-release-notes.yaml` and `release-on-push-stable.yaml`.
>     - Filters and sorts pull requests by `merged_at` date in `release-on-push-stable.yaml` to find the most recent match.
>   - **Misc**:
>     - Removes `sort` and `direction` parameters from `listClosed` function in `format-release-notes.yaml`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Lich5%2Fng-betalich&utm_source=github&utm_medium=referral)<sup> for 9119a72b2d1451ddd7a44814523fea2e94865c4c. You can [customize](https://app.ellipsis.dev/Lich5/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->