### PR TITLE
chore(all): when I say main on push

### DIFF
--- a/.github/workflows/prepare-stable-release.yaml
+++ b/.github/workflows/prepare-stable-release.yaml
@@ -43,7 +43,7 @@ jobs:
       - name: "Guard: require main as target"
         shell: bash
         env:
-          RAW_TARGET: ${{ inputs.target_branch }}
+          RAW_TARGET: ${{ inputs.target_branch || github.ref_name || 'main' }}
         run: |
           set -euo pipefail
           tgt="${RAW_TARGET:-}"
@@ -57,7 +57,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
-          ref: ${{ inputs.target_branch }}
+          ref: ${{ inputs.target_branch || github.ref_name || 'main' }}
           fetch-depth: 0
 
       - name: Git LF config (stabilize EOL)
@@ -145,7 +145,7 @@ jobs:
         with:
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
-          target-branch: ${{ inputs.target_branch }}
+          target-branch: ${{ inputs.target_branch || github.ref_name || 'main' }}
 
       # PR body and Release body formatting are handled by:
       #  - format-pr-body-stable.yml  (PR body)
@@ -155,7 +155,7 @@ jobs:
         if: always()
         env:
           EVENT: ${{ github.event_name }}
-          TARGET: ${{ inputs.target_branch }}
+          TARGET: ${{ inputs.target_branch || github.ref_name || 'main' }}
           HAS_REL: ${{ steps.guard.outputs.has_releasables }}
           CK_TAG: ${{ steps.checkpoint.outputs.tag }}
           CK_BACKUP: ${{ steps.checkpoint.outputs.backup }}


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Update `prepare-stable-release.yaml` to default `target_branch` to `github.ref_name` or 'main' if not provided.
> 
>   - **GitHub Actions Workflow**:
>     - In `prepare-stable-release.yaml`, update `target_branch` to default to `github.ref_name` or 'main' if not provided.
>     - Changes applied to steps: "Guard: require main as target", "Checkout", "release-please-action", and environment setup for release body formatting.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Lich5%2Fng-betalich&utm_source=github&utm_medium=referral)<sup> for 065247697002b447bad7fdf3a7680546f2fff642. You can [customize](https://app.ellipsis.dev/Lich5/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->