### PR TITLE
chore(all): skip a release please PR merge in prepare-stable-release

### DIFF
--- a/.github/workflows/prepare-stable-release.yaml
+++ b/.github/workflows/prepare-stable-release.yaml
@@ -54,6 +54,20 @@ jobs:
             exit 1
           fi
 
+      - name: "Classify: skip if this is the release commit"
+        id: classify
+        if: ${{ github.event_name == 'push' }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          msg="${{ github.event.head_commit.message }}"
+          if [[ "$msg" =~ ^chore\([^)]+\):[[:space:]]release ]]; then
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            echo "::notice::Skipping: release commit detected: '${msg%%$'\n'*}'"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Checkout
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
@@ -151,6 +165,13 @@ jobs:
       #  - format-pr-body-stable.yml  (PR body)
       #  - release-on-push-stable.yml + format-release-notes.yml (Release body)
       # This workflow intentionally does not format bodies.
+
+      - name: "Run summary: no-op (nothing to do)"
+        if: ${{ steps.classify.outputs.skip == 'true' || steps.guard.outputs.has_releasables != 'true' }}
+        shell: bash
+        run: |
+          echo "::notice::No releasable units on this push; workflow exiting cleanly."
+
       - name: "Run summary (prepare-stable)"
         if: always()
         env:


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Modify `prepare-stable-release.yaml` to skip workflow on release commit and exit cleanly if no releasable units.
> 
>   - **Workflow Changes**:
>     - In `prepare-stable-release.yaml`, add step to classify commit message and set `skip` flag if it matches release commit pattern.
>     - Add step to exit workflow cleanly if `skip` flag is true or no releasable units are present.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Lich5%2Fng-betalich&utm_source=github&utm_medium=referral)<sup> for 5c17748a65b7a104fd163754eaa468b6d5b9af40. You can [customize](https://app.ellipsis.dev/Lich5/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->