### PR TITLE
chore(all): fix stable release on push label detection

### DIFF
--- a/.github/workflows/release-on-push-stable.yaml
+++ b/.github/workflows/release-on-push-stable.yaml
@@ -263,7 +263,7 @@ jobs:
           want=true
           gh_api() { gh api -H 'Accept: application/vnd.github+json' "$@"; }
           ver="$(printf '%s' "$tag" | sed -nE 's/.*([0-9]+\.[0-9]+\.[0-9]+(-[A-Za-z0-9.]+)?).*/\1/p')"
-          pulls_json="$(gh_api "/repos/$repo/pulls?state=closed&base=$branch&head=${repo%%/*}:release-please--branches--$branch&per_page=100")" || pulls_json="[]"
+          pulls_json="$(gh_api "/repos/$repo/pulls?state=closed&base=$branch&sort=updated&direction=desc&per_page=100")" || pulls_json="[]"
           best="$(printf '%s' "$pulls_json" | jq -r --arg v "$ver" '
             # Escape regex metacharacters in the version string
             def esc: gsub("([.^$|()\\[\\]{}*+?\\-])"; "\\\\1");
@@ -273,9 +273,35 @@ jobs:
             | [ .merged_at, .number ] | @tsv
           ' | sort -r | head -n1)"
           pr="$(printf '%s' "$best" | awk '{print $2}')"
+          
+          # Fallback to Search (if REST scan found nothing)
+          if [ -z "${pr:-}" ]; then
+            q="repo:${repo} is:pr is:merged in:title \"${ver}\" base:${branch}"
+            echo "Gate trace (fallback): search q=$q"
+            candidates="$(gh_api "/search/issues?q=$(printf '%s' "$q" | jq -sRr @uri)&sort=updated&order=desc&per_page=10" --jq '.items[].number' 2>/dev/null || true)"
+            if [ -n "$candidates" ]; then
+              best="$(for n in $candidates; do
+                        gh_api "/repos/$repo/pulls/$n" --jq '[.merged_at,.number] | @tsv' 2>/dev/null || true
+
+  trace_build_condition:
+    needs: [release, installer_gate]
+    runs-on: ubuntu-latest
+    if: always()
+    steps:
+      - name: Trace needs for installer job
+        run: |
+          echo "release_created=${{ needs.release.outputs.release_created }}"
+          echo "installer=${{ needs.installer_gate.outputs.installer }}"
+
+                      done | sort -r | head -n1)"
+              pr="$(printf '%s' "$best" | awk '{print $2}')"
+            fi
+          fi
+          
+          echo "Gate trace: matched PR #${pr:-<none>}"
           if [ -n "${pr:-}" ]; then
             labels="$(gh_api "/repos/$repo/issues/$pr/labels" | jq -r '.[].name | ascii_downcase')"
-            if printf '%s\n' "$labels" | grep -Eq '^(skip-installer|no-installer)$'; then want=false; fi
+            if printf '%s\n' "$labels" | grep -Eq '(^|[[:space:]])(skip-installer|no-installer)($|[[:space:]])'; then want=false; fi
           fi
           echo "installer=$want" >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/release-on-push-stable.yaml
+++ b/.github/workflows/release-on-push-stable.yaml
@@ -282,17 +282,6 @@ jobs:
             if [ -n "$candidates" ]; then
               best="$(for n in $candidates; do
                         gh_api "/repos/$repo/pulls/$n" --jq '[.merged_at,.number] | @tsv' 2>/dev/null || true
-
-  trace_build_condition:
-    needs: [release, installer_gate]
-    runs-on: ubuntu-latest
-    if: always()
-    steps:
-      - name: Trace needs for installer job
-        run: |
-          echo "release_created=${{ needs.release.outputs.release_created }}"
-          echo "installer=${{ needs.installer_gate.outputs.installer }}"
-
                       done | sort -r | head -n1)"
               pr="$(printf '%s' "$best" | awk '{print $2}')"
             fi
@@ -307,6 +296,16 @@ jobs:
 
     outputs:
       installer: ${{ steps.gate.outputs.installer }}
+
+  trace_build_condition:
+    needs: [release, installer_gate]
+    runs-on: ubuntu-latest
+    if: always()
+    steps:
+      - name: Trace needs for installer job
+        run: |
+          echo "release_created=${{ needs.release.outputs.release_created }}"
+          echo "installer=${{ needs.installer_gate.outputs.installer }}"
 
   build_installer:
     needs: [release, installer_gate]


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Improve label detection and add fallback search in GitHub Actions workflow for stable releases.
> 
>   - **Workflow Changes**:
>     - In `.github/workflows/release-on-push-stable.yaml`, modify pull request query to sort by `updated` and remove `head` filter.
>     - Add fallback search mechanism for pull requests if initial query returns nothing.
>     - Update label detection to handle spaces around labels `skip-installer` and `no-installer`.
>   - **New Job**:
>     - Add `trace_build_condition` job to trace outputs of `release` and `installer_gate` jobs.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Lich5%2Fng-betalich&utm_source=github&utm_medium=referral)<sup> for fa8622a41dd069cb1b7fd8c6b39efacf80bd3c34. You can [customize](https://app.ellipsis.dev/Lich5/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->